### PR TITLE
Allowing/optimizing RGB image retrieving

### DIFF
--- a/metadrive/component/vehicle_module/base_camera.py
+++ b/metadrive/component/vehicle_module/base_camera.py
@@ -48,11 +48,13 @@ class BaseCamera(ImageBuffer):
         # TODO LQY: modify the process of getting grayscale image
         if self.attached_object is not base_object:
             self.track(base_object)
+        ret = type(self)._singleton.get_rgb_array()
         if self.engine.global_config["vehicle_config"]["rgb_to_grayscale"]:
-            return type(self)._singleton.get_grayscale_array(clip)
+            ret = np.dot(ret[..., :3], [0.299, 0.587, 0.114])
+        if not clip:
+            return ret.astype(np.uint8)
         else:
-            ret = type(self)._singleton.get_rgb_array(clip)
-            return ret
+            return ret/255
 
     def destroy(self):
         if self.initialized():

--- a/metadrive/component/vehicle_module/base_camera.py
+++ b/metadrive/component/vehicle_module/base_camera.py
@@ -53,7 +53,7 @@ class BaseCamera(ImageBuffer):
         if not clip:
             return ret.astype(np.uint8)
         else:
-            return ret/255
+            return ret / 255
 
     def destroy(self):
         if self.initialized():

--- a/metadrive/component/vehicle_module/base_camera.py
+++ b/metadrive/component/vehicle_module/base_camera.py
@@ -46,8 +46,7 @@ class BaseCamera(ImageBuffer):
 
     def get_pixels_array(self, base_object, clip=True) -> np.ndarray:
         # TODO LQY: modify the process of getting grayscale image
-        if self.attached_object is not base_object:
-            self.track(base_object)
+        self.track(base_object)
         ret = type(self)._singleton.get_rgb_array()
         if self.engine.global_config["vehicle_config"]["rgb_to_grayscale"]:
             ret = np.dot(ret[..., :3], [0.299, 0.587, 0.114])

--- a/metadrive/component/vehicle_module/base_camera.py
+++ b/metadrive/component/vehicle_module/base_camera.py
@@ -45,8 +45,14 @@ class BaseCamera(ImageBuffer):
         img.write(name)
 
     def get_pixels_array(self, base_object, clip=True) -> np.ndarray:
-        img = self.get_image(base_object)
-        return type(self)._singleton.convert_to_array(img, clip)
+        # TODO LQY: modify the process of getting grayscale image
+        if self.attached_object is not base_object:
+            self.track(base_object)
+        if self.engine.global_config["vehicle_config"]["rgb_to_grayscale"]:
+            return type(self)._singleton.get_grayscale_array(clip)
+        else:
+            ret = type(self)._singleton.get_rgb_array(clip)
+            return ret
 
     def destroy(self):
         if self.initialized():

--- a/metadrive/engine/core/image_buffer.py
+++ b/metadrive/engine/core/image_buffer.py
@@ -20,14 +20,14 @@ class ImageBuffer:
     line_borders = []
 
     def __init__(
-        self,
-        length: float,
-        width: float,
-        pos: Vec3,
-        bkg_color: Union[Vec4, Vec3],
-        parent_node: NodePath = None,
-        frame_buffer_property=None,
-        # engine=None
+            self,
+            length: float,
+            width: float,
+            pos: Vec3,
+            bkg_color: Union[Vec4, Vec3],
+            parent_node: NodePath = None,
+            frame_buffer_property=None,
+            # engine=None
     ):
         # from metadrive.engine.engine_utils import get_engine
         # self.engine = engine or get_engine()
@@ -86,15 +86,20 @@ class ImageBuffer:
         img = self.get_image()
         img.write(name)
 
-    def get_pixels_array(self, clip=True) -> np.ndarray:
-        """
-        default: For gray scale image, one channel. Override this func, when you want a new obs type
-        """
-        img = self.get_image()
-        return self.convert_to_array(img, clip)
+    def get_rgb_array(self, clip):
+        self.engine.graphicsEngine.renderFrame()
+        origin_img = self.cam.node().getDisplayRegion(0).getScreenshot()
+        v = memoryview(origin_img.getRamImage()).tolist()
+        if not clip:
+            img = np.array(v, dtype=np.uint8)
+        else:
+            img = np.array(v, dtype=np.float32) / 255
+        img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 4))
+        img = img[::-1]
+        return img
 
-    @staticmethod
-    def convert_to_array(img, clip=True):
+    def get_grayscale_array(self, clip=True):
+        img = self.get_image()
         if not clip:
             numpy_array = np.array(
                 [[int(img.getGray(i, j) * 255) for j in range(img.getYSize())] for i in range(img.getXSize())],

--- a/metadrive/engine/core/image_buffer.py
+++ b/metadrive/engine/core/image_buffer.py
@@ -20,14 +20,14 @@ class ImageBuffer:
     line_borders = []
 
     def __init__(
-            self,
-            length: float,
-            width: float,
-            pos: Vec3,
-            bkg_color: Union[Vec4, Vec3],
-            parent_node: NodePath = None,
-            frame_buffer_property=None,
-            # engine=None
+        self,
+        length: float,
+        width: float,
+        pos: Vec3,
+        bkg_color: Union[Vec4, Vec3],
+        parent_node: NodePath = None,
+        frame_buffer_property=None,
+        # engine=None
     ):
         # from metadrive.engine.engine_utils import get_engine
         # self.engine = engine or get_engine()
@@ -93,7 +93,7 @@ class ImageBuffer:
         img = np.array(v, dtype=np.uint8)
         img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 4))
         img = img[::-1]
-        return img[...,:-1]
+        return img[..., :-1]
 
     @staticmethod
     def get_grayscale_array(img, clip=True):

--- a/metadrive/engine/core/image_buffer.py
+++ b/metadrive/engine/core/image_buffer.py
@@ -86,20 +86,18 @@ class ImageBuffer:
         img = self.get_image()
         img.write(name)
 
-    def get_rgb_array(self, clip):
+    def get_rgb_array(self):
         self.engine.graphicsEngine.renderFrame()
         origin_img = self.cam.node().getDisplayRegion(0).getScreenshot()
         v = memoryview(origin_img.getRamImage()).tolist()
-        if not clip:
-            img = np.array(v, dtype=np.uint8)
-        else:
-            img = np.array(v, dtype=np.float32) / 255
+        img = np.array(v, dtype=np.uint8)
         img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 4))
         img = img[::-1]
-        return img
+        return img[...,:-1]
 
-    def get_grayscale_array(self, clip=True):
-        img = self.get_image()
+    @staticmethod
+    def get_grayscale_array(img, clip=True):
+        raise DeprecationWarning("This API is deprecated")
         if not clip:
             numpy_array = np.array(
                 [[int(img.getGray(i, j) * 255) for j in range(img.getYSize())] for i in range(img.getXSize())],

--- a/metadrive/engine/core/image_buffer.py
+++ b/metadrive/engine/core/image_buffer.py
@@ -87,7 +87,8 @@ class ImageBuffer:
         img.write(name)
 
     def get_rgb_array(self):
-        self.engine.graphicsEngine.renderFrame()
+        if self.engine.episode_step <= 1:
+            self.engine.graphicsEngine.renderFrame()
         origin_img = self.cam.node().getDisplayRegion(0).getScreenshot()
         v = memoryview(origin_img.getRamImage()).tolist()
         img = np.array(v, dtype=np.uint8)

--- a/metadrive/envs/base_env.py
+++ b/metadrive/envs/base_env.py
@@ -98,6 +98,7 @@ BASE_DEFAULT_CONFIG = dict(
 
         # NOTE: rgb_clip will be modified by env level config when initialization
         rgb_clip=True,
+        rgb_to_grayscale=False,
         gaussian_noise=0.0,
         dropout_prob=0.0,
     ),

--- a/metadrive/envs/base_env.py
+++ b/metadrive/envs/base_env.py
@@ -97,7 +97,8 @@ BASE_DEFAULT_CONFIG = dict(
         show_lane_line_detector=False,
 
         # NOTE: rgb_clip will be modified by env level config when initialization
-        rgb_clip=True,
+        rgb_clip=True,  # clip 0-255 to 0-1
+        stack_size=3,  # the number of timesteps for stacking image observation
         rgb_to_grayscale=False,
         gaussian_noise=0.0,
         dropout_prob=0.0,

--- a/metadrive/obs/image_obs.py
+++ b/metadrive/obs/image_obs.py
@@ -48,9 +48,8 @@ class ImageObservation(ObservationBase):
 
     @property
     def observation_space(self):
-        shape = (self.config[self.image_source][1], self.config[self.image_source][0]) + (
-            (self.STACK_SIZE,) if self.config[
-                "rgb_to_grayscale"] else (3, self.STACK_SIZE))
+        shape = (self.config[self.image_source][1], self.config[self.image_source][0]
+                 ) + ((self.STACK_SIZE, ) if self.config["rgb_to_grayscale"] else (3, self.STACK_SIZE))
         if self.rgb_clip:
             return gym.spaces.Box(-0.0, 1.0, shape=shape, dtype=np.float32)
         else:

--- a/metadrive/obs/image_obs.py
+++ b/metadrive/obs/image_obs.py
@@ -40,6 +40,7 @@ class ImageObservation(ObservationBase):
     STACK_SIZE = 3  # use continuous 3 image as the input
 
     def __init__(self, config, image_source: str, clip_rgb: bool):
+        self.STACK_SIZE = config["stack_size"]
         self.image_source = image_source
         super(ImageObservation, self).__init__(config)
         self.rgb_clip = clip_rgb
@@ -47,7 +48,9 @@ class ImageObservation(ObservationBase):
 
     @property
     def observation_space(self):
-        shape = tuple(self.config[self.image_source][0:2]) + (self.STACK_SIZE, )
+        shape = (self.config[self.image_source][1], self.config[self.image_source][0]) + (
+            (self.STACK_SIZE,) if self.config[
+                "rgb_to_grayscale"] else (3, self.STACK_SIZE))
         if self.rgb_clip:
             return gym.spaces.Box(-0.0, 1.0, shape=shape, dtype=np.float32)
         else:
@@ -56,7 +59,7 @@ class ImageObservation(ObservationBase):
     def observe(self, vehicle):
         new_obs = vehicle.image_sensors[self.image_source].get_pixels_array(vehicle, self.rgb_clip)
         self.state = np.roll(self.state, -1, axis=-1)
-        self.state[:, :, -1] = new_obs
+        self.state[..., -1] = new_obs
         return self.state
 
     def get_image(self):

--- a/metadrive/tests/vis_functionality/profile_rgb_cam.py
+++ b/metadrive/tests/vis_functionality/profile_rgb_cam.py
@@ -8,7 +8,10 @@ if __name__ == "__main__":
             "environment_num": 1,
             "traffic_density": 0.1,
             "start_seed": 4,
-            "vehicle_config": {"stack_size": 5,  "rgb_camera": (64, 64)},
+            "vehicle_config": {
+                "stack_size": 5,
+                "rgb_camera": (64, 64)
+            },
             "manual_control": True,
             "use_render": False,
             "offscreen_render": True,  # it is a switch telling metadrive to use rgb as observation
@@ -25,8 +28,8 @@ if __name__ == "__main__":
     for i in range(1, 100000):
         o, r, d, info = env.step([0, 0])
         assert env.observation_space.contains(o)
-        if i%1000==0:
-            print("FPS: {}".format(i/(time.time()-start)))
+        if i % 1000 == 0:
+            print("FPS: {}".format(i / (time.time() - start)))
         if d:
             print("Reset")
             env.reset()

--- a/metadrive/tests/vis_functionality/profile_rgb_cam.py
+++ b/metadrive/tests/vis_functionality/profile_rgb_cam.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
             "traffic_density": 0.1,
             "start_seed": 4,
             "vehicle_config": {
-                "stack_size": 5,
+                # "stack_size": 5,
                 "rgb_camera": (64, 64)
             },
             "manual_control": True,

--- a/metadrive/tests/vis_functionality/profile_rgb_cam.py
+++ b/metadrive/tests/vis_functionality/profile_rgb_cam.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
             "environment_num": 1,
             "traffic_density": 0.1,
             "start_seed": 4,
-            "vehicle_config": {"stack_size": 5, "rgb_clip": False, "rgb_camera": (64, 64)},
+            "vehicle_config": {"stack_size": 5,  "rgb_camera": (64, 64)},
             "manual_control": True,
             "use_render": False,
             "offscreen_render": True,  # it is a switch telling metadrive to use rgb as observation

--- a/metadrive/tests/vis_functionality/profile_rgb_cam.py
+++ b/metadrive/tests/vis_functionality/profile_rgb_cam.py
@@ -1,0 +1,33 @@
+import time
+
+from metadrive.envs.metadrive_env import MetaDriveEnv
+
+if __name__ == "__main__":
+    env = MetaDriveEnv(
+        {
+            "environment_num": 1,
+            "traffic_density": 0.1,
+            "start_seed": 4,
+            "vehicle_config": {"stack_size": 5, "rgb_clip": False, "rgb_camera": (64, 64)},
+            "manual_control": True,
+            "use_render": False,
+            "offscreen_render": True,  # it is a switch telling metadrive to use rgb as observation
+            "rgb_clip": True,  # clip rgb to range(0,1) instead of (0, 255)
+            # "pstats": True,
+        }
+    )
+    env.reset()
+    # print m to capture rgb observation
+    env.engine.accept(
+        "m", env.vehicle.image_sensors[env.vehicle.config["image_source"]].save_image, extraArgs=[env.vehicle]
+    )
+    start = time.time()
+    for i in range(1, 100000):
+        o, r, d, info = env.step([0, 0])
+        assert env.observation_space.contains(o)
+        if i%1000==0:
+            print("FPS: {}".format(i/(time.time()-start)))
+        if d:
+            print("Reset")
+            env.reset()
+    env.close()

--- a/metadrive/tests/vis_functionality/vis_grayscale_cam.py
+++ b/metadrive/tests/vis_functionality/vis_grayscale_cam.py
@@ -6,7 +6,12 @@ if __name__ == "__main__":
             "environment_num": 1,
             "traffic_density": 0.1,
             "start_seed": 4,
-            "vehicle_config": {"stack_size": 5, "rgb_clip": False, "rgb_camera": (800, 500), "rgb_to_grayscale":True},
+            "vehicle_config": {
+                "stack_size": 5,
+                "rgb_clip": False,
+                "rgb_camera": (800, 500),
+                "rgb_to_grayscale": True
+            },
             "manual_control": True,
             "use_render": False,
             "offscreen_render": True,  # it is a switch telling metadrive to use rgb as observation
@@ -28,7 +33,7 @@ if __name__ == "__main__":
         # save
         rgb_cam = env.vehicle.image_sensors[env.vehicle.config["image_source"]]
         rgb_cam.save_image(env.vehicle, name="{}.png".format(i))
-        cv2.imshow('img', o["image"][..., -1]/255)
+        cv2.imshow('img', o["image"][..., -1] / 255)
         cv2.waitKey(0)
 
         # if env.config["use_render"]:

--- a/metadrive/tests/vis_functionality/vis_grayscale_cam.py
+++ b/metadrive/tests/vis_functionality/vis_grayscale_cam.py
@@ -6,11 +6,11 @@ if __name__ == "__main__":
             "environment_num": 1,
             "traffic_density": 0.1,
             "start_seed": 4,
-            "vehicle_config": {"stack_size": 5, "rgb_clip": False, "rgb_camera": (800, 500)},
+            "vehicle_config": {"stack_size": 5, "rgb_clip": False, "rgb_camera": (800, 500), "rgb_to_grayscale":True},
             "manual_control": True,
             "use_render": False,
             "offscreen_render": True,  # it is a switch telling metadrive to use rgb as observation
-            "rgb_clip": True,  # clip rgb to range(0,1) instead of (0, 255)
+            "rgb_clip": False,  # clip rgb to range(0,1) instead of (0, 255)
             # "pstats": True,
         }
     )
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         # save
         rgb_cam = env.vehicle.image_sensors[env.vehicle.config["image_source"]]
         rgb_cam.save_image(env.vehicle, name="{}.png".format(i))
-        cv2.imshow('img', o["image"][..., -1])
+        cv2.imshow('img', o["image"][..., -1]/255)
         cv2.waitKey(0)
 
         # if env.config["use_render"]:

--- a/metadrive/tests/vis_functionality/vis_rgb_cam.py
+++ b/metadrive/tests/vis_functionality/vis_rgb_cam.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
             "use_render": False,
             "offscreen_render": True,  # it is a switch telling metadrive to use rgb as observation
             "rgb_clip": True,  # clip rgb to range(0,1) instead of (0, 255)
-            "pstats": True,
+            # "pstats": True,
         }
     )
     env.reset()
@@ -18,11 +18,18 @@ if __name__ == "__main__":
     env.engine.accept(
         "m", env.vehicle.image_sensors[env.vehicle.config["image_source"]].save_image, extraArgs=[env.vehicle]
     )
-
+    import numpy as np
+    import cv2
     for i in range(1, 100000):
         o, r, d, info = env.step([0, 1])
         assert env.observation_space.contains(o)
+        # save
+        rgb_cam = env.vehicle.image_sensors[env.vehicle.config["image_source"]]
+        img = rgb_cam.get_rgb_array(clip=False)
         env.vehicle.image_sensors[env.vehicle.config["image_source"]].save_image(env.vehicle, name="{}.png".format(i))
+        cv2.imshow('img', img)
+        cv2.waitKey(0)
+
         # if env.config["use_render"]:
         # for i in range(ImageObservation.STACK_SIZE):
         #      ObservationType.show_gray_scale_array(o["image"][:, :, i])

--- a/metadrive/tests/vis_functionality/vis_rgb_cam.py
+++ b/metadrive/tests/vis_functionality/vis_rgb_cam.py
@@ -6,7 +6,11 @@ if __name__ == "__main__":
             "environment_num": 1,
             "traffic_density": 0.1,
             "start_seed": 4,
-            "vehicle_config": {"stack_size": 5, "rgb_clip": False, "rgb_camera": (800, 500)},
+            "vehicle_config": {
+                "stack_size": 5,
+                "rgb_clip": False,
+                "rgb_camera": (800, 500)
+            },
             "manual_control": True,
             "use_render": False,
             "offscreen_render": True,  # it is a switch telling metadrive to use rgb as observation

--- a/metadrive/tests/vis_functionality/vis_shared_camera.py
+++ b/metadrive/tests/vis_functionality/vis_shared_camera.py
@@ -1,0 +1,21 @@
+from metadrive.envs.marl_envs.marl_parking_lot import MultiAgentParkingLotEnv
+import cv2
+
+
+def vis_ma_parking_lot_env():
+    env = MultiAgentParkingLotEnv({"use_render": False,
+                                   "offscreen_render": True,
+                                   # it is a switch telling metadrive to use rgb as observation
+                                   "rgb_clip": True,  # clip rgb to range(0,1) instead of (0, 255)
+                                   "delay_done": 0, "num_agents": 4,
+                                   "vehicle_config": {"stack_size": 5, "rgb_camera": (800, 600),
+                                                      "lidar": {"num_others": 8}}})
+    env.reset()
+    o, r, d, i = env.step(env.action_space.sample())
+    for i in range(4):
+        cv2.imshow('img', o["agent{}".format(i)]["image"][..., -1])
+        cv2.waitKey(0)
+
+
+if __name__ == '__main__':
+    vis_ma_parking_lot_env()

--- a/metadrive/tests/vis_functionality/vis_shared_camera.py
+++ b/metadrive/tests/vis_functionality/vis_shared_camera.py
@@ -3,13 +3,23 @@ import cv2
 
 
 def vis_ma_parking_lot_env():
-    env = MultiAgentParkingLotEnv({"use_render": False,
-                                   "offscreen_render": True,
-                                   # it is a switch telling metadrive to use rgb as observation
-                                   "rgb_clip": True,  # clip rgb to range(0,1) instead of (0, 255)
-                                   "delay_done": 0, "num_agents": 4,
-                                   "vehicle_config": {"stack_size": 5, "rgb_camera": (800, 600),
-                                                      "lidar": {"num_others": 8}}})
+    env = MultiAgentParkingLotEnv(
+        {
+            "use_render": False,
+            "offscreen_render": True,
+            # it is a switch telling metadrive to use rgb as observation
+            "rgb_clip": True,  # clip rgb to range(0,1) instead of (0, 255)
+            "delay_done": 0,
+            "num_agents": 4,
+            "vehicle_config": {
+                "stack_size": 5,
+                "rgb_camera": (800, 600),
+                "lidar": {
+                    "num_others": 8
+                }
+            }
+        }
+    )
     env.reset()
     o, r, d, i = env.step(env.action_space.sample())
     for i in range(4):


### PR DESCRIPTION
Previously, the returned image of RGBCamera is the grayscale image. Now, we add a config```rgb_to_grayscale``` to allow returning RGB image.


## Checklist

* [x] I have merged the latest main branch into current branch.
* [x] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
