### PR TITLE
Fix the memory leak in waymo map

### DIFF
--- a/metadrive/base_class/base_runnable.py
+++ b/metadrive/base_class/base_runnable.py
@@ -94,3 +94,8 @@ class BaseRunnable(Configurable, Nameable, Randomizable):
 
     def destroy(self):
         Configurable.destroy(self)
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/base_class/configurable.py
+++ b/metadrive/base_class/configurable.py
@@ -32,8 +32,8 @@ class Configurable:
         Fully delete this element and release the memory
         """
         self._config.clear()
-        if hasattr(self, "engine"):
-            self.engine = None
+        # if hasattr(self, "engine"):
+        #     self.engine = None
 
     @property
     def config(self):

--- a/metadrive/component/map/base_map.py
+++ b/metadrive/component/map/base_map.py
@@ -48,7 +48,7 @@ class BaseMap(BaseRunnable):
         self.blocks = []
 
         # Generate map and insert blocks
-        self.engine = get_engine()
+        # self.engine = get_engine()
         self._generate()
         assert self.blocks, "The generate methods does not fill blocks!"
 

--- a/metadrive/component/nuplan_block/nuplan_block.py
+++ b/metadrive/component/nuplan_block/nuplan_block.py
@@ -34,7 +34,7 @@ class NuPlanBlock(BaseBlock):
         super(NuPlanBlock, self).__init__(block_index, global_network, random_seed)
 
         # authorize engine access for this object
-        self.engine = get_engine()
+        # self.engine = get_engine()
         self._nuplan_map_api = self.engine.data_manager.get_case(self.map_index).map_api
         # TODO LQY, make it a dict
         self.lines = {}

--- a/metadrive/component/vehicle/base_vehicle.py
+++ b/metadrive/component/vehicle/base_vehicle.py
@@ -133,7 +133,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
         assert engine_initialized(), "Please make sure game engine is successfully initialized!"
 
         # NOTE: it is the game engine, not vehicle drivetrain
-        self.engine = get_engine()
+        # self.engine = get_engine()
         BaseObject.__init__(self, name, random_seed, self.engine.global_config["vehicle_config"])
         BaseVehicleState.__init__(self)
         self.update_config(vehicle_config)
@@ -755,7 +755,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
             for sensor in self.image_sensors.values():
                 sensor.destroy()
         self.image_sensors = {}
-        self.engine = None
+        # self.engine = None
 
     def set_heading_theta(self, heading_theta, rad_to_degree=True) -> None:
         """
@@ -853,7 +853,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
 
     def __del__(self):
         super(BaseVehicle, self).__del__()
-        self.engine = None
+        # self.engine = None
         self.lidar = None
         self.mini_map = None
         self.rgb_camera = None

--- a/metadrive/component/vehicle/base_vehicle.py
+++ b/metadrive/component/vehicle/base_vehicle.py
@@ -793,11 +793,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
         return state
 
     def get_raw_state(self):
-        ret = dict(
-            position=self.position,
-            heading=self.heading,
-            velocity=self.velocity
-        )
+        ret = dict(position=self.position, heading=self.heading, velocity=self.velocity)
         return ret
 
     def get_dynamics_parameters(self):
@@ -820,7 +816,6 @@ class BaseVehicle(BaseObject, BaseVehicleState):
             mass=mass
         )
         return ret
-
 
     def set_state(self, state):
         super(BaseVehicle, self).set_state(state)

--- a/metadrive/component/vehicle/base_vehicle.py
+++ b/metadrive/component/vehicle/base_vehicle.py
@@ -795,9 +795,9 @@ class BaseVehicle(BaseObject, BaseVehicleState):
             )
         return state
 
-    def get_raw_state(self):
-        ret = dict(position=self.position, heading=self.heading, velocity=self.velocity)
-        return ret
+    # def get_raw_state(self):
+    #     ret = dict(position=self.position, heading=self.heading, velocity=self.velocity)
+    #     return ret
 
     def get_dynamics_parameters(self):
         # These two can be changed on the fly

--- a/metadrive/component/vehicle/base_vehicle.py
+++ b/metadrive/component/vehicle/base_vehicle.py
@@ -649,7 +649,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
             navi = NodeNetworkNavigation if self.engine.current_map.road_network_type == NodeRoadNetwork \
                 else EdgeNetworkNavigation
         self.navigation = navi(
-            self.engine,
+            # self.engine,
             show_navi_mark=self.engine.global_config["vehicle_config"]["show_navi_mark"],
             random_navi_mark_color=self.engine.global_config["vehicle_config"]["random_navi_mark_color"],
             show_dest_mark=self.engine.global_config["vehicle_config"]["show_dest_mark"],

--- a/metadrive/component/vehicle/base_vehicle.py
+++ b/metadrive/component/vehicle/base_vehicle.py
@@ -93,7 +93,9 @@ class BaseVehicle(BaseObject, BaseVehicleState):
     TIRE_WIDTH = 0.4
     FRONT_WHEELBASE = None
     REAR_WHEELBASE = None
-    MASS = None
+
+    # MASS = None
+
     CHASSIS_TO_WHEEL_AXIS = 0.2
     SUSPENSION_LENGTH = 15
     SUSPENSION_STIFFNESS = 40
@@ -789,6 +791,36 @@ class BaseVehicle(BaseObject, BaseVehicleState):
                 }
             )
         return state
+
+    def get_raw_state(self):
+        ret = dict(
+            position=self.position,
+            heading=self.heading,
+            velocity=self.velocity
+        )
+        return ret
+
+    def get_dynamics_parameters(self):
+        # These two can be changed on the fly
+        max_engine_force = self.config["max_engine_force"]
+        max_brake_force = self.config["max_brake_force"]
+
+        # These two can only be changed in init
+        wheel_friction = self.config["wheel_friction"]
+        assert self.max_steering == self.config["max_steering"]
+        max_steering = self.max_steering
+
+        mass = self.config["mass"] if self.config["mass"] else self.MASS
+
+        ret = dict(
+            max_engine_force=max_engine_force,
+            max_brake_force=max_brake_force,
+            wheel_friction=wheel_friction,
+            max_steering=max_steering,
+            mass=mass
+        )
+        return ret
+
 
     def set_state(self, state):
         super(BaseVehicle, self).set_state(state)

--- a/metadrive/component/vehicle/vehicle_type.py
+++ b/metadrive/component/vehicle/vehicle_type.py
@@ -215,7 +215,17 @@ class VaryingShapeVehicle(DefaultVehicle):
                     vehicle_config["mass"] != self.config["mass"]:
                 should_force_reset = True
 
+        # def process_memory():
+        #     import psutil
+        #     import os
+        #     process = psutil.Process(os.getpid())
+        #     mem_info = process.memory_info()
+        #     return mem_info.rss
+        #
+        # cm = process_memory()
+
         if should_force_reset:
+
             self.destroy()
             self.__init__(
                 vehicle_config=vehicle_config,
@@ -225,8 +235,18 @@ class VaryingShapeVehicle(DefaultVehicle):
                 heading=heading
             )
 
+            # lm = process_memory()
+            # print("{}:  Reset! Mem Change {:.3f}MB".format("1 Force Re-Init Vehicle", (lm - cm) / 1e6))
+            # cm = lm
+
         assert self.max_steering == self.config["max_steering"]
 
-        return super(VaryingShapeVehicle, self).reset(
+        ret = super(VaryingShapeVehicle, self).reset(
             random_seed=random_seed, vehicle_config=vehicle_config, position=position, heading=heading, *args, **kwargs
         )
+
+        # lm = process_memory()
+        # print("{}:  Reset! Mem Change {:.3f}MB".format("2 Force Reset Vehicle", (lm - cm) / 1e6))
+        # cm = lm
+
+        return ret

--- a/metadrive/component/vehicle/vehicle_type.py
+++ b/metadrive/component/vehicle/vehicle_type.py
@@ -210,7 +210,6 @@ class VaryingShapeVehicle(DefaultVehicle):
                     vehicle_config["max_steering"] != self.config["max_steering"]:
                 self.max_steering = vehicle_config["max_steering"]
                 should_force_reset = True
-                assert self.max_steering == self.config["max_steering"]
             if "mass" in vehicle_config and \
                     vehicle_config["mass"] is not None and \
                     vehicle_config["mass"] != self.config["mass"]:

--- a/metadrive/component/vehicle/vehicle_type.py
+++ b/metadrive/component/vehicle/vehicle_type.py
@@ -168,6 +168,10 @@ class VaryingShapeVehicle(DefaultVehicle):
     def HEIGHT(self):
         return self.config["height"] if self.config["height"] is not None else super(VaryingShapeVehicle, self).HEIGHT
 
+    @property
+    def MASS(self):
+        return self.config["mass"] if self.config["mass"] is not None else super(VaryingShapeVehicle, self).MASS
+
     def reset(
         self,
         random_seed=None,
@@ -189,6 +193,29 @@ class VaryingShapeVehicle(DefaultVehicle):
                 should_force_reset = True
             if vehicle_config["length"] is not None and vehicle_config["length"] != self.LENGTH:
                 should_force_reset = True
+            if "max_engine_force" in vehicle_config and \
+                    vehicle_config["max_engine_force"] is not None and \
+                    vehicle_config["max_engine_force"] != self.config["max_engine_force"]:
+                should_force_reset = True
+            if "max_brake_force" in vehicle_config and \
+                    vehicle_config["max_brake_force"] is not None and \
+                    vehicle_config["max_brake_force"] != self.config["max_brake_force"]:
+                should_force_reset = True
+            if "wheel_friction" in vehicle_config and \
+                    vehicle_config["wheel_friction"] is not None and \
+                    vehicle_config["wheel_friction"] != self.config["wheel_friction"]:
+                should_force_reset = True
+            if "max_steering" in vehicle_config and \
+                    vehicle_config["max_steering"] is not None and \
+                    vehicle_config["max_steering"] != self.config["max_steering"]:
+                self.max_steering = vehicle_config["max_steering"]
+                should_force_reset = True
+                assert self.max_steering == self.config["max_steering"]
+            if "mass" in vehicle_config and \
+                    vehicle_config["mass"] is not None and \
+                    vehicle_config["mass"] != self.config["mass"]:
+                should_force_reset = True
+
         if should_force_reset:
             self.destroy()
             self.__init__(
@@ -198,6 +225,8 @@ class VaryingShapeVehicle(DefaultVehicle):
                 position=position,
                 heading=heading
             )
+
+        assert self.max_steering == self.config["max_steering"]
 
         return super(VaryingShapeVehicle, self).reset(
             random_seed=random_seed, vehicle_config=vehicle_config, position=position, heading=heading, *args, **kwargs

--- a/metadrive/component/vehicle_navigation_module/base_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/base_navigation.py
@@ -26,7 +26,7 @@ class BaseNavigation:
 
     def __init__(
         self,
-        engine,
+        # engine,
         show_navi_mark: bool = False,
         random_navi_mark_color=False,
         show_dest_mark=False,
@@ -39,7 +39,7 @@ class BaseNavigation:
         This class define a helper for localizing vehicles and retrieving navigation information.
         It now only support from first block start to the end node, but can be extended easily.
         """
-        self.engine = engine
+        # self.engine = engine
         self.name = name
 
         # Make sure these variables are filled when making new subclass
@@ -248,3 +248,8 @@ class BaseNavigation:
         for np in self._node_path_list:
             np.detachNode()
             np.removeNode()
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/component/vehicle_navigation_module/base_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/base_navigation.py
@@ -53,7 +53,9 @@ class BaseNavigation:
         self._navi_info = np.zeros((self.navigation_info_dim, ), dtype=np.float32)  # navi information res
 
         # Vis
-        self._show_navi_info = (self.engine.mode == RENDER_MODE_ONSCREEN and not self.engine.global_config["debug_physics_world"])
+        self._show_navi_info = (
+            self.engine.mode == RENDER_MODE_ONSCREEN and not self.engine.global_config["debug_physics_world"]
+        )
         self.origin = NodePath("navigation_sign") if self._show_navi_info else None
         self.navi_mark_color = (0.6, 0.8, 0.5) if not random_navi_mark_color else get_np_random().rand(3)
         if panda_color is not None:

--- a/metadrive/component/vehicle_navigation_module/base_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/base_navigation.py
@@ -41,12 +41,13 @@ class BaseNavigation:
         self.name = name
 
         # Make sure these variables are filled when making new subclass
-        self.map = None
-        self.checkpoints = None
-        self.current_ref_lanes = None
-        self.next_ref_lanes = None
-        self.final_lane = None
-        self.current_lane = None
+        # self.map = None
+        # self.checkpoints = None
+        # self.current_ref_lanes = None
+        # self.next_ref_lanes = None
+        # self.final_lane = None
+        # self.current_lane = None
+
         self.vehicle_config = vehicle_config
 
         self._target_checkpoints_index = None
@@ -127,9 +128,13 @@ class BaseNavigation:
 
     def reset(self, map: BaseMap, current_lane, vehicle_config=None):
         self.map = map
-        self.current_lane = current_lane
+        self._current_lane = current_lane
         if vehicle_config is not None:
             self.vehicle_config = vehicle_config
+
+    @property
+    def current_lane(self):
+        return self._current_lane
 
     def get_checkpoints(self):
         """Return next checkpoint and the next next checkpoint"""

--- a/metadrive/component/vehicle_navigation_module/base_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/base_navigation.py
@@ -53,7 +53,7 @@ class BaseNavigation:
         self._navi_info = np.zeros((self.navigation_info_dim, ), dtype=np.float32)  # navi information res
 
         # Vis
-        self._show_navi_info = (engine.mode == RENDER_MODE_ONSCREEN and not engine.global_config["debug_physics_world"])
+        self._show_navi_info = (self.engine.mode == RENDER_MODE_ONSCREEN and not self.engine.global_config["debug_physics_world"])
         self.origin = NodePath("navigation_sign") if self._show_navi_info else None
         self.navi_mark_color = (0.6, 0.8, 0.5) if not random_navi_mark_color else get_np_random().rand(3)
         if panda_color is not None:

--- a/metadrive/component/vehicle_navigation_module/base_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/base_navigation.py
@@ -26,7 +26,6 @@ class BaseNavigation:
 
     def __init__(
         self,
-        # engine,
         show_navi_mark: bool = False,
         random_navi_mark_color=False,
         show_dest_mark=False,
@@ -39,7 +38,6 @@ class BaseNavigation:
         This class define a helper for localizing vehicles and retrieving navigation information.
         It now only support from first block start to the end node, but can be extended easily.
         """
-        # self.engine = engine
         self.name = name
 
         # Make sure these variables are filled when making new subclass

--- a/metadrive/component/vehicle_navigation_module/edge_network_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/edge_network_navigation.py
@@ -15,7 +15,6 @@ class EdgeNetworkNavigation(BaseNavigation):
    """
     def __init__(
         self,
-        engine,
         show_navi_mark: bool = False,
         random_navi_mark_color=False,
         show_dest_mark=False,
@@ -25,7 +24,6 @@ class EdgeNetworkNavigation(BaseNavigation):
         vehicle_config=None
     ):
         super(EdgeNetworkNavigation, self).__init__(
-            engine=engine,
             show_navi_mark=show_navi_mark,
             random_navi_mark_color=random_navi_mark_color,
             show_dest_mark=show_dest_mark,

--- a/metadrive/component/vehicle_navigation_module/node_network_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/node_network_navigation.py
@@ -16,7 +16,6 @@ from metadrive.utils.space import Parameter, BlockParameterSpace
 class NodeNetworkNavigation(BaseNavigation):
     def __init__(
         self,
-        engine,
         show_navi_mark: bool = False,
         random_navi_mark_color=False,
         show_dest_mark=False,
@@ -30,7 +29,6 @@ class NodeNetworkNavigation(BaseNavigation):
         It now only support from first block start to the end node, but can be extended easily.
         """
         super(NodeNetworkNavigation, self).__init__(
-            engine=engine,
             show_navi_mark=show_navi_mark,
             random_navi_mark_color=random_navi_mark_color,
             show_dest_mark=show_dest_mark,

--- a/metadrive/component/vehicle_navigation_module/node_network_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/node_network_navigation.py
@@ -279,6 +279,6 @@ class NodeNetworkNavigation(BaseNavigation):
             if self.FORCE_CALCULATE:
                 lane_index, _ = self.map.road_network.get_closest_lane_index(ego_vehicle.position)
                 lane = self.map.road_network.get_lane(lane_index)
-        self.current_lane = lane
+        self._current_lane = lane
         assert lane_index == lane.index, "lane index mismatch!"
         return lane, lane_index

--- a/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
@@ -42,13 +42,10 @@ class WaymoTrajectoryNavigation(BaseNavigation):
         #  caching a class local variable.
         super(WaymoTrajectoryNavigation, self).reset(map=None, current_lane=None)
 
-
         # self.reference_trajectory = self.get_trajectory()
-
 
         if self.reference_trajectory is not None:
             self.set_route(None, None)
-
 
     @property
     def reference_trajectory(self):

--- a/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
@@ -31,15 +31,15 @@ class TrajectoryNavigation(BaseNavigation):
             name=name,
             vehicle_config=vehicle_config
         )
-        self.reference_trajectory = None
+        # self.reference_trajectory = None
 
     def reset(self, map=None, current_lane=None, destination=None, random_seed=None):
 
         # We do not want to store map within the navigation module!
         # TODO(PZH): In future, we can let all navigation module get latest map on-the-fly instead of
         #  caching a class local variable.
-        super(TrajectoryNavigation, self).reset(map=None, current_lane=None)
-        self.reference_trajectory = self.get_trajectory()
+        super(TrajectoryNavigation, self).reset(map=map, current_lane=current_lane)
+        # self.reference_trajectory = self.get_trajectory()
         if self.reference_trajectory is not None:
             self.set_route(None, None)
 
@@ -171,21 +171,21 @@ class TrajectoryNavigation(BaseNavigation):
     def destroy(self):
         self.map = None
         self.checkpoints = None
-        self.current_ref_lanes = None
+        # self.current_ref_lanes = None
         self.next_ref_lanes = None
         self.final_lane = None
-        self.current_lane = None
+        self._current_lane = None
         # self.reference_trajectory = None
         super(TrajectoryNavigation, self).destroy()
 
     def before_reset(self):
         self.map = None
         self.checkpoints = None
-        self.current_ref_lanes = None
+        # self.current_ref_lanes = None
         self.next_ref_lanes = None
         self.final_lane = None
-        self.current_lane = None
-        self.reference_trajectory = None
+        self._current_lane = None
+        # self.reference_trajectory = None
 
 
 WaymoTrajectoryNavigation = TrajectoryNavigation

--- a/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
@@ -41,9 +41,22 @@ class WaymoTrajectoryNavigation(BaseNavigation):
         # TODO(PZH): In future, we can let all navigation module get latest map on-the-fly instead of
         #  caching a class local variable.
         super(WaymoTrajectoryNavigation, self).reset(map=None, current_lane=None)
-        self.reference_trajectory = self.get_trajectory()
+
+
+        # self.reference_trajectory = self.get_trajectory()
+
+
         if self.reference_trajectory is not None:
             self.set_route(None, None)
+
+
+    @property
+    def reference_trajectory(self):
+        return self.engine.map_manager.current_sdc_route
+
+    @property
+    def current_ref_lanes(self):
+        return [self.reference_trajectory]
 
     def set_route(self, current_lane_index: str, destination: str):
         self.checkpoints = self.descretize_reference_trajectory()
@@ -53,16 +66,16 @@ class WaymoTrajectoryNavigation(BaseNavigation):
         #            ) >= 2, "Can not find a route from {} to {}".format(current_lane_index[0], destination)
 
         self._navi_info.fill(0.0)
-        self.current_ref_lanes = [self.reference_trajectory]
+        # self.current_ref_lanes = [self.reference_trajectory]
         self.next_ref_lanes = None
-        self.current_lane = self.final_lane = self.reference_trajectory
+        # self.current_lane = self.final_lane = self.reference_trajectory
         if self._dest_node_path is not None:
             check_point = self.reference_trajectory.end
             self._dest_node_path.setPos(check_point[0], -check_point[1], 1.8)
 
-    def get_trajectory(self):
-        """This function breaks Multi-agent Waymo Env since we don't set this in map_manager."""
-        return self.engine.map_manager.current_sdc_route
+    # def get_trajectory(self):
+    #     """This function breaks Multi-agent Waymo Env since we don't set this in map_manager."""
+    #     return self.engine.map_manager.current_sdc_route
 
     def descretize_reference_trajectory(self):
         ret = []
@@ -169,7 +182,7 @@ class WaymoTrajectoryNavigation(BaseNavigation):
         self.next_ref_lanes = None
         self.final_lane = None
         self.current_lane = None
-        self.reference_trajectory = None
+        # self.reference_trajectory = None
         super(WaymoTrajectoryNavigation, self).destroy()
 
     def before_reset(self):

--- a/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
+++ b/metadrive/component/vehicle_navigation_module/trajectory_navigation.py
@@ -14,7 +14,6 @@ class WaymoTrajectoryNavigation(BaseNavigation):
 
     def __init__(
         self,
-        engine,
         show_navi_mark: bool = False,
         random_navi_mark_color=False,
         show_dest_mark=False,
@@ -24,7 +23,6 @@ class WaymoTrajectoryNavigation(BaseNavigation):
         vehicle_config=None
     ):
         super(WaymoTrajectoryNavigation, self).__init__(
-            engine=engine,
             show_navi_mark=show_navi_mark,
             random_navi_mark_color=random_navi_mark_color,
             show_dest_mark=show_dest_mark,

--- a/metadrive/component/waymo_block/waymo_block.py
+++ b/metadrive/component/waymo_block/waymo_block.py
@@ -20,7 +20,7 @@ class WaymoBlock(BaseBlock):
         super(WaymoBlock, self).__init__(block_index, global_network, random_seed)
         #
         # e = get_engine()
-        # self.waymo_map_data = e.data_manager.get_case(self.map_index)["map"]
+        # self.waymo_map_data = e.data_manager.get_case(self.map_index, should_copy=True)["map"]
 
     @property
     def waymo_map_data(self):
@@ -135,7 +135,7 @@ class WaymoBlock(BaseBlock):
 
     def destroy(self):
         self.map_index = None
-        self.waymo_map_data = None
+        # self.waymo_map_data = None
         super(WaymoBlock, self).destroy()
 
     def __del__(self):

--- a/metadrive/component/waymo_block/waymo_block.py
+++ b/metadrive/component/waymo_block/waymo_block.py
@@ -27,7 +27,6 @@ class WaymoBlock(BaseBlock):
         e = get_engine()
         return e.data_manager.get_case(self.map_index, should_copy=False)["map"]
 
-
     def _sample_topology(self) -> bool:
         for lane_id, data in self.waymo_map_data.items():
             if data.get("type", False) == WaymoLaneProperty.LANE_TYPE:

--- a/metadrive/component/waymo_block/waymo_block.py
+++ b/metadrive/component/waymo_block/waymo_block.py
@@ -18,11 +18,15 @@ class WaymoBlock(BaseBlock):
         # self.waymo_map_data = waymo_map_data
         self.map_index = map_index
         super(WaymoBlock, self).__init__(block_index, global_network, random_seed)
+        #
+        # e = get_engine()
+        # self.waymo_map_data = e.data_manager.get_case(self.map_index)["map"]
 
+    @property
+    def waymo_map_data(self):
         e = get_engine()
-        self.waymo_map_data = e.data_manager.get_case(self.map_index)["map"]
+        return e.data_manager.get_case(self.map_index, should_copy=False)["map"]
 
-        # print(1)
 
     def _sample_topology(self) -> bool:
         for lane_id, data in self.waymo_map_data.items():

--- a/metadrive/engine/base_engine.py
+++ b/metadrive/engine/base_engine.py
@@ -225,9 +225,9 @@ class BaseEngine(EngineCore, Randomizable):
         self.record_episode = self.global_config["record_episode"]
         self.only_reset_when_replay = self.global_config["only_reset_when_replay"]
 
-        _profile_memory_usage = False
+        _debug_memory_usage = False
 
-        if _profile_memory_usage:
+        if _debug_memory_usage:
             def process_memory():
                 import psutil
                 import os
@@ -242,9 +242,10 @@ class BaseEngine(EngineCore, Randomizable):
             # clean all manager
             manager.before_reset()
 
-            if _profile_memory_usage:
+            if _debug_memory_usage:
                 lm = process_memory()
-                print("{}: Before Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
+                if lm - cm != 0:
+                    print("{}: Before Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
                 cm = lm
 
         self._object_clean_check()
@@ -255,17 +256,19 @@ class BaseEngine(EngineCore, Randomizable):
                 continue
             manager.reset()
 
-            if _profile_memory_usage:
+            if _debug_memory_usage:
                 lm = process_memory()
-                print("{}: Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
+                if lm - cm != 0:
+                    print("{}: Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
                 cm = lm
 
         for manager_name, manager in self.managers.items():
             manager.after_reset()
 
-            if _profile_memory_usage:
+            if _debug_memory_usage:
                 lm = process_memory()
-                print("{}: After Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
+                if lm - cm != 0:
+                    print("{}: After Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
                 cm = lm
 
         # reset cam

--- a/metadrive/engine/base_engine.py
+++ b/metadrive/engine/base_engine.py
@@ -228,6 +228,7 @@ class BaseEngine(EngineCore, Randomizable):
         _debug_memory_usage = True
 
         if _debug_memory_usage:
+
             def process_memory():
                 import psutil
                 import os

--- a/metadrive/engine/base_engine.py
+++ b/metadrive/engine/base_engine.py
@@ -225,23 +225,27 @@ class BaseEngine(EngineCore, Randomizable):
         self.record_episode = self.global_config["record_episode"]
         self.only_reset_when_replay = self.global_config["only_reset_when_replay"]
 
-        # def process_memory():
-        #     import psutil
-        #     import os
-        #     process = psutil.Process(os.getpid())
-        #     mem_info = process.memory_info()
-        #     return mem_info.rss
-        #
-        # cm = process_memory()
+        _profile_memory_usage = False
+
+        if _profile_memory_usage:
+            def process_memory():
+                import psutil
+                import os
+                process = psutil.Process(os.getpid())
+                mem_info = process.memory_info()
+                return mem_info.rss
+
+            cm = process_memory()
 
         # reset manager
         for manager_name, manager in self._managers.items():
             # clean all manager
             manager.before_reset()
 
-            # lm = process_memory()
-            # print("{}: Before Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
-            # cm = lm
+            if _profile_memory_usage:
+                lm = process_memory()
+                print("{}: Before Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
+                cm = lm
 
         self._object_clean_check()
 
@@ -251,16 +255,18 @@ class BaseEngine(EngineCore, Randomizable):
                 continue
             manager.reset()
 
-            # lm = process_memory()
-            # print("{}: Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
-            # cm = lm
+            if _profile_memory_usage:
+                lm = process_memory()
+                print("{}: Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
+                cm = lm
 
         for manager_name, manager in self.managers.items():
             manager.after_reset()
 
-            # lm = process_memory()
-            # print("{}: After Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
-            # cm = lm
+            if _profile_memory_usage:
+                lm = process_memory()
+                print("{}: After Reset! Mem Change {:.3f}MB".format(manager_name, (lm - cm) / 1e6))
+                cm = lm
 
         # reset cam
         if self.main_camera is not None:

--- a/metadrive/engine/base_engine.py
+++ b/metadrive/engine/base_engine.py
@@ -208,6 +208,7 @@ class BaseEngine(EngineCore, Randomizable):
             self._dying_objects[obj.class_name].remove(obj)
             if hasattr(obj, "destroy"):
                 obj.destroy()
+        del obj
 
     def reset(self):
         """

--- a/metadrive/engine/base_engine.py
+++ b/metadrive/engine/base_engine.py
@@ -225,7 +225,7 @@ class BaseEngine(EngineCore, Randomizable):
         self.record_episode = self.global_config["record_episode"]
         self.only_reset_when_replay = self.global_config["only_reset_when_replay"]
 
-        _debug_memory_usage = False
+        _debug_memory_usage = True
 
         if _debug_memory_usage:
             def process_memory():

--- a/metadrive/engine/base_engine.py
+++ b/metadrive/engine/base_engine.py
@@ -225,7 +225,7 @@ class BaseEngine(EngineCore, Randomizable):
         self.record_episode = self.global_config["record_episode"]
         self.only_reset_when_replay = self.global_config["only_reset_when_replay"]
 
-        _debug_memory_usage = True
+        _debug_memory_usage = False
 
         if _debug_memory_usage:
 

--- a/metadrive/engine/core/chase_camera.py
+++ b/metadrive/engine/core/chase_camera.py
@@ -31,7 +31,7 @@ class MainCamera:
 
     def __init__(self, engine, camera_height: float, camera_dist: float):
         self._origin_height = camera_height
-        self.engine = engine
+        # self.engine = engine
 
         # vehicle chase camera
         self.camera = engine.cam
@@ -325,3 +325,8 @@ class MainCamera:
     @property
     def mouse_into_window(self):
         return True if not self._last_frame_has_mouse and self.has_mouse else False
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/engine/core/force_fps.py
+++ b/metadrive/engine/core/force_fps.py
@@ -8,7 +8,7 @@ class ForceFPS:
     FORCED = "ForceFPS"
 
     def __init__(self, engine):
-        self.engine = engine
+        # self.engine = engine
         if engine.global_config["force_render_fps"] is None:
             interval = engine.global_config["physics_world_step_size"]
         else:
@@ -50,3 +50,8 @@ class ForceFPS:
     @property
     def real_time_simulation(self):
         return self.state == self.FORCED and self.engine.mode == RENDER_MODE_ONSCREEN
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/engine/interface.py
+++ b/metadrive/engine/interface.py
@@ -18,7 +18,7 @@ class Interface:
 
     def __init__(self, base_engine):
         self._node_path_list = []
-        self.engine = base_engine
+        # self.engine = base_engine
         self.vehicle_panel = None
         self.right_panel = None
         self.mid_panel = None
@@ -305,3 +305,8 @@ class VehiclePanel(ImageBuffer):
         for para in self.para_vis_np.values():
             para.removeNode()
         self.aspect2d_np.removeNode()
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/engine/interface.py
+++ b/metadrive/engine/interface.py
@@ -29,7 +29,7 @@ class Interface:
         self._right_arrow = None
         self._contact_banners = {}  # to save time/memory
         self.current_banner = None
-        self.need_interface = self.engine.mode == RENDER_MODE_ONSCREEN and not self.engine.global_config[
+        self.need_interface = base_engine.mode == RENDER_MODE_ONSCREEN and not base_engine.global_config[
             "debug_physics_world"]
         self.need_interface = self.need_interface and base_engine.global_config["show_interface"]
         self.init_interface()
@@ -186,6 +186,10 @@ class Interface:
                 if self._left_arrow.hasParent():
                     self._left_arrow.detachNode()
 
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()
 
 class VehiclePanel(ImageBuffer):
     PARA_VIS_LENGTH = 12

--- a/metadrive/engine/interface.py
+++ b/metadrive/engine/interface.py
@@ -191,6 +191,7 @@ class Interface:
         from metadrive.engine.engine_utils import get_engine
         return get_engine()
 
+
 class VehiclePanel(ImageBuffer):
     PARA_VIS_LENGTH = 12
     PARA_VIS_HEIGHT = 1

--- a/metadrive/envs/base_env.py
+++ b/metadrive/envs/base_env.py
@@ -91,6 +91,7 @@ BASE_DEFAULT_CONFIG = dict(
         width=None,
         length=None,
         height=None,
+        mass=None,
 
         # ===== vehicle module config =====
         lidar=dict(

--- a/metadrive/envs/base_env.py
+++ b/metadrive/envs/base_env.py
@@ -196,7 +196,7 @@ class BaseEnv(gym.Env):
         )
 
         # lazy initialization, create the main vehicle in the lazy_init() func
-        self.engine: Optional[BaseEngine] = None
+        # self.engine: Optional[BaseEngine] = None
 
         # In MARL envs with respawn mechanism, varying episode lengths might happen.
         self.dones = None
@@ -245,11 +245,16 @@ class BaseEnv(gym.Env):
         # It is the true init() func to create the main vehicle and its module, to avoid incompatible with ray
         if engine_initialized():
             return
-        self.engine = initialize_engine(self.config)
+        engine = initialize_engine(self.config)
         # engine setup
         self.setup_engine()
         # other optional initialization
         self._after_lazy_init()
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()
 
     def _after_lazy_init(self):
         pass

--- a/metadrive/manager/agent_manager.py
+++ b/metadrive/manager/agent_manager.py
@@ -291,7 +291,7 @@ class AgentManager(BaseManager):
         """
         Return Map<agent_id, BaseVehicle>
         """
-        if hasattr(self, "engine") and self.engine.replay_episode:
+        if hasattr(self, "engine") and self.engine is not None and self.engine.replay_episode:
             return self.engine.replay_manager.replay_agents
         else:
             return {self._object_to_agent[k]: v for k, v in self._active_objects.items()}

--- a/metadrive/manager/base_manager.py
+++ b/metadrive/manager/base_manager.py
@@ -58,7 +58,7 @@ class BaseManager(Randomizable):
         """
         Destroy manager
         """
-        self.engine = None
+        # self.engine = None
         self.spawned_objects = None
 
     def spawn_object(self, object_class, **kwargs):

--- a/metadrive/manager/base_manager.py
+++ b/metadrive/manager/base_manager.py
@@ -11,8 +11,8 @@ class BaseManager(Randomizable):
     def __init__(self):
         from metadrive.engine.engine_utils import get_engine, engine_initialized
         assert engine_initialized(), "You should not create manager before the initialization of BaseEngine"
-        self.engine = get_engine()
-        Randomizable.__init__(self, self.engine.global_random_seed)
+        # self.engine = get_engine()
+        Randomizable.__init__(self, get_engine().global_random_seed)
         self.spawned_objects = {}
 
     @property
@@ -118,3 +118,8 @@ class BaseManager(Randomizable):
     @property
     def class_name(self):
         return self.__class__.__name__
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/manager/waymo_data_manager.py
+++ b/metadrive/manager/waymo_data_manager.py
@@ -31,9 +31,9 @@ class WaymoDataManager(BaseManager):
         assert self.start_case_index <= i < self.start_case_index + self.case_num, \
             "Case ID exceeds range"
         file_path = os.path.join(self.directory, "{}.pkl".format(i))
-        return copy.deepcopy(read_waymo_data(file_path))
+        return read_waymo_data(file_path)
 
-    def get_case(self, i):
+    def get_case(self, i, should_copy=False):
         if i not in self.waymo_case:
             # inner psutil function
             # def process_memory():
@@ -51,11 +51,17 @@ class WaymoDataManager(BaseManager):
             # print("{}:  Reset! Mem Change {:.3f}MB".format("data manager 1", (lm - cm) / 1e6))
             # cm = lm
 
+            # print("===Getting new case: ", i)
             self.waymo_case[i] = self._get_case(i)
 
             # lm = process_memory()
             # print("{}:  Reset! Mem Change {:.3f}MB".format("data manager 2", (lm - cm) / 1e6))
             # cm = lm
 
-        # return copy.deepcopy(self.waymo_case[i])
+        else:
+            pass
+            # print("===Don't need to get new case. Just return: ", i)
+
+        if should_copy:
+            return copy.deepcopy(self.waymo_case[i])
         return self.waymo_case[i]

--- a/metadrive/manager/waymo_data_manager.py
+++ b/metadrive/manager/waymo_data_manager.py
@@ -20,6 +20,7 @@ class WaymoDataManager(BaseManager):
         self.start_case_index = engine.global_config["start_case_index"]
 
         self.store_map = store_map
+
         self.waymo_case = DataBuffer(store_map_buffer_size if self.store_map else self.case_num)
 
         for i in tqdm(range(self.start_case_index, self.start_case_index + self.case_num), desc="Check Waymo Data"):

--- a/metadrive/manager/waymo_map_manager.py
+++ b/metadrive/manager/waymo_map_manager.py
@@ -137,7 +137,6 @@ class WaymoMapManager(BaseManager):
 
     def unload_map(self, map):
         map.detach_from_world()
-        del map
         self.current_map = None
 
         # if not self.engine.global_config["store_map"]:

--- a/metadrive/manager/waymo_map_manager.py
+++ b/metadrive/manager/waymo_map_manager.py
@@ -121,9 +121,13 @@ class WaymoMapManager(BaseManager):
 
         self.engine.global_config.update(
             copy.deepcopy(
-                dict(target_vehicle_configs={DEFAULT_AGENT: dict(
-                    spawn_position_heading=(init_position, init_yaw), spawn_velocity=init_state["velocity"])
-                })
+                dict(
+                    target_vehicle_configs={
+                        DEFAULT_AGENT: dict(
+                            spawn_position_heading=(init_position, init_yaw), spawn_velocity=init_state["velocity"]
+                        )
+                    }
+                )
             )
         )
 

--- a/metadrive/manager/waymo_map_manager.py
+++ b/metadrive/manager/waymo_map_manager.py
@@ -58,21 +58,21 @@ class WaymoMapManager(BaseManager):
         #
         #     self.store_map_buffer.clear_if_necessary()
 
-            # lm = process_memory()
-            # print("{}:  Reset! Mem Change {:.3f}MB".format(2, (lm - cm) / 1e6))
-            # cm = lm
+        # lm = process_memory()
+        # print("{}:  Reset! Mem Change {:.3f}MB".format(2, (lm - cm) / 1e6))
+        # cm = lm
 
         new_map = WaymoMap(map_index=seed)
 
-            # lm = process_memory()
-            # print("{}:  Reset! Mem Change {:.3f}MB".format(3, (lm - cm) / 1e6))
-            # cm = lm
+        # lm = process_memory()
+        # print("{}:  Reset! Mem Change {:.3f}MB".format(3, (lm - cm) / 1e6))
+        # cm = lm
 
-            # self.store_map_buffer[seed] = new_map
+        # self.store_map_buffer[seed] = new_map
 
-            # lm = process_memory()
-            # print("{}:  Reset! Mem Change {:.3f}MB".format(4, (lm - cm) / 1e6))
-            # cm = lm
+        # lm = process_memory()
+        # print("{}:  Reset! Mem Change {:.3f}MB".format(4, (lm - cm) / 1e6))
+        # cm = lm
 
         self.load_map(new_map)
 
@@ -114,7 +114,9 @@ class WaymoMapManager(BaseManager):
         self.sdc_dest_point = copy.deepcopy(last_position)
 
         self.engine.global_config.update(
-            copy.deepcopy(dict(target_vehicle_configs={DEFAULT_AGENT: dict(spawn_position_heading=(init_position, init_yaw))}))
+            copy.deepcopy(
+                dict(target_vehicle_configs={DEFAULT_AGENT: dict(spawn_position_heading=(init_position, init_yaw))})
+            )
         )
 
     def filter_path(self, start_lanes, end_lanes):

--- a/metadrive/manager/waymo_map_manager.py
+++ b/metadrive/manager/waymo_map_manager.py
@@ -1,12 +1,10 @@
-from metadrive.component.lane.point_lane import PointLane
 import copy
 
-from metadrive.component.lane.waypoint_lane import WayPointLane
+from metadrive.component.lane.point_lane import PointLane
 from metadrive.component.map.waymo_map import WaymoMap
 from metadrive.constants import DEFAULT_AGENT
 from metadrive.manager.base_manager import BaseManager
 from metadrive.manager.waymo_traffic_manager import WaymoTrafficManager
-from metadrive.utils.data_buffer import DataBuffer
 
 
 class WaymoMapManager(BaseManager):
@@ -115,7 +113,7 @@ class WaymoMapManager(BaseManager):
         last_position = last_state["position"]
         last_yaw = last_state["heading"]
 
-        self.current_sdc_route = copy.deepcopy(WayPointLane(sdc_traj, 1.5))
+        self.current_sdc_route = copy.deepcopy(PointLane(sdc_traj, 1.5))
 
         self.sdc_dest_point = copy.deepcopy(last_position)
 

--- a/metadrive/manager/waymo_map_manager.py
+++ b/metadrive/manager/waymo_map_manager.py
@@ -25,22 +25,9 @@ class WaymoMapManager(BaseManager):
         self.sdc_dest_point = None
         self.current_sdc_route = None
 
-        # self.store_map = store_map
-        # self.store_map_buffer = DataBuffer(store_data_buffer_size=store_map_buffer_size if self.store_map else None)
-
     def reset(self):
         seed = self.engine.global_random_seed
         assert self.start <= seed < self.start + self.map_num
-
-        # inner psutil function
-        # def process_memory():
-        #     import psutil
-        #     import os
-        #     process = psutil.Process(os.getpid())
-        #     mem_info = process.memory_info()
-        #     return mem_info.rss
-        #
-        # cm = process_memory()
 
         self.current_sdc_route = None
         self.sdc_dest_point = None
@@ -48,52 +35,12 @@ class WaymoMapManager(BaseManager):
         seed = self.engine.global_random_seed
         assert self.start <= seed < self.start + self.map_num
 
-        # lm = process_memory()
-        # print("{}:  Reset! Mem Change {:.3f}MB".format(0, (lm - cm) / 1e6))
-        # cm = lm
-
-        # if seed in self.store_map_buffer:
-        #     new_map = self.store_map_buffer[seed]
-        # else:
-        #
-        #     # lm = process_memory()
-        #     # print("{}:  Reset! Mem Change {:.3f}MB".format(1, (lm - cm) / 1e6))
-        #     # cm = lm
-        #
-        #     self.store_map_buffer.clear_if_necessary()
-
-        # lm = process_memory()
-        # print("{}:  Reset! Mem Change {:.3f}MB".format(2, (lm - cm) / 1e6))
-        # cm = lm
-
         new_map = WaymoMap(map_index=seed)
-
-        # lm = process_memory()
-        # print("{}:  Reset! Mem Change {:.3f}MB".format(3, (lm - cm) / 1e6))
-        # cm = lm
-
-        # self.store_map_buffer[seed] = new_map
-
-        # lm = process_memory()
-        # print("{}:  Reset! Mem Change {:.3f}MB".format(4, (lm - cm) / 1e6))
-        # cm = lm
-
         self.load_map(new_map)
-
-        # lm = process_memory()
-        # print("{}:  Reset! Mem Change {:.3f}MB".format(5, (lm - cm) / 1e6))
-        # cm = lm
 
         self.update_route()
 
-        # lm = process_memory()
-        # print("{}:  Reset! Mem Change {:.3f}MB".format(6, (lm - cm) / 1e6))
-        # cm = lm
-
     def update_route(self):
-        """
-        # TODO(LQY) Modify this part, if we finally deceide to use TrajNavi
-        """
         data = self.engine.data_manager.get_case(self.engine.global_random_seed)
 
         sdc_traj = WaymoTrafficManager.parse_full_trajectory(data["tracks"][data["sdc_index"]]["state"])

--- a/metadrive/manager/waymo_map_manager.py
+++ b/metadrive/manager/waymo_map_manager.py
@@ -23,8 +23,8 @@ class WaymoMapManager(BaseManager):
         self.sdc_dest_point = None
         self.current_sdc_route = None
 
-        self.store_map = store_map
-        self.store_map_buffer = DataBuffer(store_data_buffer_size=store_map_buffer_size if self.store_map else None)
+        # self.store_map = store_map
+        # self.store_map_buffer = DataBuffer(store_data_buffer_size=store_map_buffer_size if self.store_map else None)
 
     def reset(self):
 
@@ -48,27 +48,27 @@ class WaymoMapManager(BaseManager):
         # print("{}:  Reset! Mem Change {:.3f}MB".format(0, (lm - cm) / 1e6))
         # cm = lm
 
-        if seed in self.store_map_buffer:
-            new_map = self.store_map_buffer[seed]
-        else:
-
-            # lm = process_memory()
-            # print("{}:  Reset! Mem Change {:.3f}MB".format(1, (lm - cm) / 1e6))
-            # cm = lm
-
-            self.store_map_buffer.clear_if_necessary()
+        # if seed in self.store_map_buffer:
+        #     new_map = self.store_map_buffer[seed]
+        # else:
+        #
+        #     # lm = process_memory()
+        #     # print("{}:  Reset! Mem Change {:.3f}MB".format(1, (lm - cm) / 1e6))
+        #     # cm = lm
+        #
+        #     self.store_map_buffer.clear_if_necessary()
 
             # lm = process_memory()
             # print("{}:  Reset! Mem Change {:.3f}MB".format(2, (lm - cm) / 1e6))
             # cm = lm
 
-            new_map = WaymoMap(map_index=seed)
+        new_map = WaymoMap(map_index=seed)
 
             # lm = process_memory()
             # print("{}:  Reset! Mem Change {:.3f}MB".format(3, (lm - cm) / 1e6))
             # cm = lm
 
-            self.store_map_buffer[seed] = new_map
+            # self.store_map_buffer[seed] = new_map
 
             # lm = process_memory()
             # print("{}:  Reset! Mem Change {:.3f}MB".format(4, (lm - cm) / 1e6))
@@ -137,7 +137,9 @@ class WaymoMapManager(BaseManager):
 
     def unload_map(self, map):
         map.detach_from_world()
+        del map
         self.current_map = None
+
         # if not self.engine.global_config["store_map"]:
         #     self.clear_objects([map.id])
         #     assert len(self.spawned_objects) == 0
@@ -162,6 +164,7 @@ class WaymoMapManager(BaseManager):
         self.sdc_destinations = []
         self.sdc_dest_point = None
         self.current_sdc_route = None
+        self.current_map = None
 
     def clear_objects(self, *args, **kwargs):
         """

--- a/metadrive/obs/top_down_obs.py
+++ b/metadrive/obs/top_down_obs.py
@@ -50,7 +50,7 @@ class TopDownObservation(ObservationBase):
 
         # scene
         self.road_network = None
-        self.engine = None
+        # self.engine = None
 
         # initialize
         pygame.init()
@@ -75,7 +75,7 @@ class TopDownObservation(ObservationBase):
         self.canvas_background = WorldSurface(self.MAP_RESOLUTION, 0, pygame.Surface(self.MAP_RESOLUTION))
 
     def reset(self, env, vehicle=None):
-        self.engine = env.engine
+        # self.engine = env.engine
         self.road_network = env.current_map.road_network
         self._should_draw_map = True
 
@@ -228,3 +228,8 @@ class TopDownObservation(ObservationBase):
         else:
             img = img.astype(np.uint8)
         return np.transpose(img, (1, 0, 2))
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/obs/top_down_obs_multi_channel.py
+++ b/metadrive/obs/top_down_obs_multi_channel.py
@@ -67,7 +67,7 @@ class TopDownMultiChannel(TopDownObservation):
         self.canvas_past_pos = pygame.Surface(self.resolution)  # A local view
 
     def reset(self, env, vehicle=None):
-        self.engine = env.engine
+        # self.engine = env.engine
         self.road_network = env.current_map.road_network
         self.target_vehicle = vehicle
         self._should_draw_map = True

--- a/metadrive/obs/top_down_renderer.py
+++ b/metadrive/obs/top_down_renderer.py
@@ -148,7 +148,7 @@ class TopDownRenderer:
         self.show_agent_name = show_agent_name
         if self.show_agent_name:
             pygame.init()
-        self.engine = get_engine()
+        # self.engine = get_engine()
         # self._screen_size = screen_size
         self.pygame_font = None
         self.map = self.engine.current_map
@@ -412,3 +412,8 @@ class TopDownRenderer:
                 if event.key == pygame.K_ESCAPE:
                     import sys
                     sys.exit()
+
+    @property
+    def engine(self):
+        from metadrive.engine.engine_utils import get_engine
+        return get_engine()

--- a/metadrive/policy/base_policy.py
+++ b/metadrive/policy/base_policy.py
@@ -9,7 +9,7 @@ class BasePolicy(Randomizable, Configurable):
     def __init__(self, control_object, random_seed=None, config=None):
         Randomizable.__init__(self, random_seed)
         Configurable.__init__(self, config)
-        self.engine = get_engine()
+        # self.engine = get_engine()
         self.control_object = control_object
         self.action_info = dict()
 
@@ -33,7 +33,7 @@ class BasePolicy(Randomizable, Configurable):
         logging.debug("{} is released".format(self.__class__.__name__))
         super(BasePolicy, self).destroy()
         self.control_object = None
-        self.engine = None
+        # self.engine = None
 
     @property
     def name(self):
@@ -41,3 +41,7 @@ class BasePolicy(Randomizable, Configurable):
 
     def __repr__(self):
         return self.name
+
+    @property
+    def engine(self):
+        return get_engine()

--- a/metadrive/tests/test_functionality/test_marl_reborn.py
+++ b/metadrive/tests/test_functionality/test_marl_reborn.py
@@ -16,12 +16,14 @@ def test_respawn():
         }
     )
     try:
-        assert set(env.observations.keys()) == {"agent0", "agent1"}
+
         assert set(env.action_space.spaces.keys()) == {"agent0", "agent1"}
         assert set(env.config["target_vehicle_configs"].keys()) == {"agent0", "agent1"}
         assert set(env.vehicles.keys()) == set()  # Not initialized yet!
 
         o = env.reset()
+
+        assert set(env.observations.keys()) == {"agent0", "agent1"}
 
         assert set(o.keys()) == {"agent0", "agent1"}
         assert set(env.observations.keys()) == {"agent0", "agent1"}
@@ -148,5 +150,5 @@ def test_delay_done(render=False):
 
 if __name__ == '__main__':
     # setup_logger(True)
-    # test_respawn()
-    test_delay_done(True)
+    test_respawn()
+    # test_delay_done(True)

--- a/metadrive/tests/test_functionality/test_memory_leak_waymo_map.py
+++ b/metadrive/tests/test_functionality/test_memory_leak_waymo_map.py
@@ -8,13 +8,13 @@ from metadrive.manager.waymo_data_manager import WaymoDataManager
 from metadrive.tests.test_functionality.test_memory_leak_engine import process_memory
 
 
-def test_waymo_env_memory_leak():
+def test_waymo_env_memory_leak(num_reset=20):
     env = WaymoEnv(dict(case_num=2, sequential_seed=True, store_map=True, store_map_buffer_size=1))
 
     try:
         ct = time.time()
         cm = process_memory()
-        for t in range(20):
+        for t in range(num_reset):
             lt = time.time()
             env.reset()
             nlt = time.time()
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     # gc.enable()
     # gc.set_debug(gc.DEBUG_LEAK)
 
-    test_waymo_env_memory_leak()
+    test_waymo_env_memory_leak(num_reset=300)
 
     test_waymo_map_memory_leak()
 

--- a/metadrive/tests/test_functionality/test_memory_leak_waymo_map.py
+++ b/metadrive/tests/test_functionality/test_memory_leak_waymo_map.py
@@ -8,7 +8,7 @@ from metadrive.manager.waymo_data_manager import WaymoDataManager
 from metadrive.tests.test_functionality.test_memory_leak_engine import process_memory
 
 
-def test_waymo_env_memory_leak(num_reset=20):
+def test_waymo_env_memory_leak(num_reset=100):
     env = WaymoEnv(dict(case_num=2, sequential_seed=True, store_map=True, store_map_buffer_size=1))
 
     try:

--- a/metadrive/utils/waymo_utils/data_buffer.py
+++ b/metadrive/utils/waymo_utils/data_buffer.py
@@ -1,7 +1,31 @@
 from collections import deque
 
 from metadrive.engine.engine_utils import get_engine
+from collections import Iterable
+import numpy as np
 
+def _clear_if_necessary(obj, depth=0):
+    if depth > 5:
+        obj = None
+        del obj
+        return
+
+    if isinstance(obj, dict):
+        keys = set(obj.keys())
+        for k in keys:
+            if k in obj:
+                _clear_if_necessary(obj[k], depth + 1)
+                obj[k] = None
+        obj.clear()
+    elif isinstance(obj, str):
+        del obj
+    elif isinstance(obj, list):
+        obj.clear()
+        del obj
+    elif isinstance(obj, np.ndarray):
+        del obj
+    else:
+        del obj
 
 class DataBuffer:
     """
@@ -32,7 +56,8 @@ class DataBuffer:
             if hasattr(tmp_obj, "destroy"):
                 print("Destroy object: ", type(tmp_obj))
                 tmp_obj.destroy()
-            del tmp_obj
+
+            _clear_if_necessary(tmp_obj)
 
     def __getitem__(self, item):
         assert item in self.store_data_buffer

--- a/metadrive/utils/waymo_utils/data_buffer.py
+++ b/metadrive/utils/waymo_utils/data_buffer.py
@@ -34,6 +34,7 @@ class DataBuffer:
     The maximum size of the buffer is determined by store_data_buffer_size
     """
     def __init__(self, store_data_buffer_size=None):
+
         self.store_data_buffer = {}
 
         if store_data_buffer_size is None:

--- a/metadrive/utils/waymo_utils/data_buffer.py
+++ b/metadrive/utils/waymo_utils/data_buffer.py
@@ -4,6 +4,7 @@ from metadrive.engine.engine_utils import get_engine
 from collections import Iterable
 import numpy as np
 
+
 def _clear_if_necessary(obj, depth=0):
     if depth > 5:
         obj = None
@@ -26,6 +27,7 @@ def _clear_if_necessary(obj, depth=0):
         del obj
     else:
         del obj
+
 
 class DataBuffer:
     """

--- a/metadrive/utils/waymo_utils/waymo_utils.py
+++ b/metadrive/utils/waymo_utils/waymo_utils.py
@@ -169,12 +169,12 @@ def extract_crosswalk(f):
 
 
 def extract_bump(f):
-    speed_bump = dict()
+    speed_bump_data = dict()
     f = f.speed_bump
-    speed_bump['type'] = speed_bump
-    speed_bump['polygon'] = extract_poly(f.polygon)
+    speed_bump_data['type'] = "speed_bump"
+    speed_bump_data['polygon'] = extract_poly(f.polygon)
 
-    return speed_bump
+    return speed_bump_data
 
 
 def extract_tracks(f, sdc_idx):


### PR DESCRIPTION
## What changes do you make in this PR?

* Please describe why you create this PR

In this PR, we turn all self.engine into property. So that there will not be a reference within object's member variables that links to the engine.

If many objects link to the engine, while the engine itself link to many objects, this forms circular reference and has the high risk to cause memory leak. 

We can verify this by watching `test_memory_leak_waymo_map.py` 

## Checklist

* [x] I have merged the latest main branch into current branch.
* [x] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
