### PR TITLE
fix a rendering bug for top_down mode in multi-agent envs

### DIFF
--- a/metadrive/obs/top_down_renderer.py
+++ b/metadrive/obs/top_down_renderer.py
@@ -446,8 +446,11 @@ class TopDownRenderer:
         canvas = self._runtime_canvas
         field = self._render_canvas.get_size()
         if not self.target_vehicle_heading_up:
-            cam_pos = v.position if self.position is None else self.position
-            position = self._runtime_canvas.pos2pix(*cam_pos)
+            if self.position is not None or v is not None:
+                cam_pos = (self.position or v.position)
+                position = self._runtime_canvas.pos2pix(*cam_pos)
+            else:
+                position = (field[0] / 2, field[1] / 2)
             off = (position[0] - field[0] / 2, position[1] - field[1] / 2)
             self.canvas.blit(source=canvas, dest=(0, 0), area=(off[0], off[1], field[0], field[1]))
         else:


### PR DESCRIPTION
I found that in multi-agent envs, if render mode is top_down, it will fail rendering on my Mac. I figure out that the `position` attribute in `TopDownRenderer` class will be initialized as None. It's ok for the `_draw` method while in single-agent env, b/c the `self.current_track_vehicle` will have a value and is not None. But in MA Envs, since there is no `self.current_track_vehicle`, it will cause a bug of None Type error.  I kind of fix it by following code in previous version of MetaDrive repo. Hope it will help!

## What changes do you make in this PR?

* Please describe why you create this PR

## Checklist

* [ ] I have merged the latest main branch into current branch.
* [ ] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
