### PR TITLE
ImageBuffer: prevent additional copy converting from RGBA to RGB

### DIFF
--- a/metadrive/component/sensors/base_camera.py
+++ b/metadrive/component/sensors/base_camera.py
@@ -110,7 +110,7 @@ class BaseCamera(ImageBuffer, BaseSensor):
         if self.engine.global_config["rgb_to_grayscale"]:
             ret = np.dot(ret[..., :3], [0.299, 0.587, 0.114])
         if not clip:
-            return ret.astype(np.uint8)
+            return ret.astype(np.uint8, copy=False, order="C")
         else:
             return ret / 255
 

--- a/metadrive/engine/core/image_buffer.py
+++ b/metadrive/engine/core/image_buffer.py
@@ -5,7 +5,7 @@ from simplepbr import _load_shader_str
 from typing import Union, List
 
 import numpy as np
-from panda3d.core import NodePath, Vec3, Vec4, Camera, PNMImage, Shader, RenderState, ShaderAttrib
+from panda3d.core import NodePath, Vec3, Vec4, Camera, PNMImage, Shader, RenderState, ShaderAttrib, FrameBufferProperties
 
 from metadrive.constants import RENDER_MODE_ONSCREEN, BKG_COLOR, RENDER_MODE_NONE
 
@@ -51,6 +51,9 @@ class ImageBuffer:
 
             self.lens = self.cam.node().getLens()
             return
+        
+        frame_buffer_property = FrameBufferProperties()
+        frame_buffer_property.set_rgba_bits(8,8,8,0) # disable alpha for RGB camera
 
         # self.texture = Texture()
         if frame_buffer_property is None:
@@ -102,10 +105,9 @@ class ImageBuffer:
     def get_rgb_array_cpu(self):
         origin_img = self.buffer.getDisplayRegion(1).getScreenshot()
         img = np.frombuffer(origin_img.getRamImage().getData(), dtype=np.uint8)
-        img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 4))
+        img = img.reshape((origin_img.getYSize(), origin_img.getXSize(), 3))
         # img = np.swapaxes(img, 1, 0)
         img = img[::-1]
-        img = img[..., :-1]
         return img
 
     @staticmethod

--- a/metadrive/engine/core/image_buffer.py
+++ b/metadrive/engine/core/image_buffer.py
@@ -51,9 +51,9 @@ class ImageBuffer:
 
             self.lens = self.cam.node().getLens()
             return
-        
+
         frame_buffer_property = FrameBufferProperties()
-        frame_buffer_property.set_rgba_bits(8,8,8,0) # disable alpha for RGB camera
+        frame_buffer_property.set_rgba_bits(8, 8, 8, 0)  # disable alpha for RGB camera
 
         # self.texture = Texture()
         if frame_buffer_property is None:


### PR DESCRIPTION
np.astype will perform a full copy of the array, which is very slow for large images (was taking 30ms for a 1920x1080 image). Our application requires grabbing these images in realtime, and this was taking significant portion of the time. You can avoid this copy if the array is contiguous. However, if the texture buffer is RGBA, the array won't be contiguous, so I disabled RGBA in the output texture. This improved the performance of grabbing images from the engine

If RGBA isn't used anywhere else, the frame_buffer_properties can go directly into ImageBuffer as I have it now. If not, perhaps it should go into BaseCamera or RGBCamera, or be based on the CamMask that you have selected