### PR TITLE
Escape backlashes in bottleneck.py

### DIFF
--- a/metadrive/component/pgblock/bottleneck.py
+++ b/metadrive/component/pgblock/bottleneck.py
@@ -32,8 +32,8 @@ class Bottleneck(PGBlock):
 
 class Merge(Bottleneck):
     """
-    -----\
-          \
+    -----\\
+          \\
            -------------------
            -------------------
           /
@@ -180,8 +180,8 @@ class Split(Bottleneck):
                        /
     -------------------
     -------------------
-                       \
-                        \-----
+                       \\
+                        \\-----
     OutBottlecneck
     """
     ID = "Y"


### PR DESCRIPTION
was causing an invalid escape sequence

```
  File "/home/batman/pyenv/versions/3.11.4/lib/python3.11/site-packages/metadrive/component/pgblock/bottleneck.py", line 178

    """

    ^^^

SyntaxError: invalid escape sequence '\-'
```