### PR TITLE
Add prefix to object before spawning to avoid object registered twice in engine

### DIFF
--- a/metadrive/manager/scenario_light_manager.py
+++ b/metadrive/manager/scenario_light_manager.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__file__)
 class ScenarioLightManager(BaseManager):
     CLEAR_LIGHTS = False
 
+    OBJECT_PREFIX = "traffic_light_"
+
     def __init__(self):
         super(ScenarioLightManager, self).__init__()
         self._scenario_id_to_obj_id = {}
@@ -41,12 +43,14 @@ class ScenarioLightManager(BaseManager):
                     )
             lane_info = self.engine.current_map.road_network.graph[str(scenario_lane_id)]
             position = self._get_light_position(light_info)
-            name = scenario_lane_id if self.engine.global_config["force_reuse_object_name"] else None
+            name = self.OBJECT_PREFIX + scenario_lane_id if self.engine.global_config["force_reuse_object_name"] else None
             traffic_light = self.spawn_object(ScenarioTrafficLight, lane=lane_info.lane, position=position, name=name)
             self._scenario_id_to_obj_id[scenario_lane_id] = traffic_light.id
             self._obj_id_to_scenario_id[traffic_light.id] = scenario_lane_id
             if self.engine.global_config["force_reuse_object_name"]:
-                assert scenario_lane_id == traffic_light.id, "Original id should be assigned to traffic lights"
+                assert self.OBJECT_PREFIX +  scenario_lane_id == traffic_light.id, (
+                    "Original id should be assigned to traffic lights"
+                )
             self._lane_index_to_obj[lane_info.lane.index] = traffic_light
             status = light_info[SD.TRAFFIC_LIGHT_STATUS][self.episode_step]
             traffic_light.set_status(status)

--- a/metadrive/manager/scenario_light_manager.py
+++ b/metadrive/manager/scenario_light_manager.py
@@ -43,12 +43,13 @@ class ScenarioLightManager(BaseManager):
                     )
             lane_info = self.engine.current_map.road_network.graph[str(scenario_lane_id)]
             position = self._get_light_position(light_info)
-            name = self.OBJECT_PREFIX + scenario_lane_id if self.engine.global_config["force_reuse_object_name"] else None
+            name = self.OBJECT_PREFIX + scenario_lane_id if self.engine.global_config["force_reuse_object_name"
+                                                                                      ] else None
             traffic_light = self.spawn_object(ScenarioTrafficLight, lane=lane_info.lane, position=position, name=name)
             self._scenario_id_to_obj_id[scenario_lane_id] = traffic_light.id
             self._obj_id_to_scenario_id[traffic_light.id] = scenario_lane_id
             if self.engine.global_config["force_reuse_object_name"]:
-                assert self.OBJECT_PREFIX +  scenario_lane_id == traffic_light.id, (
+                assert self.OBJECT_PREFIX + scenario_lane_id == traffic_light.id, (
                     "Original id should be assigned to traffic lights"
                 )
             self._lane_index_to_obj[lane_info.lane.index] = traffic_light


### PR DESCRIPTION

## What changes do you make in this PR?

* Please describe why you create this PR

now I add a prefix to Scenariotrafficlight manager's objects. From '162' to 'traffic_light_162'. This is because the Scenariotrafficmanager will also generate a traffc vehicle with name '162'. They will use the same name in the engine's registry. So when `clear_objects` from engine, the trafficmanager will remove '162'. Later when ScenarioTrafficLight manager want to remove '162', error will be raised in engine as the object already removed.



WE MIGHT ALSO WANT TO ADD PREFIX TO ALL OBJECTS SPAWN BY MANAGERS?



## Checklist

* [ ] I have merged the latest main branch into current branch.
* [ ] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
