### PR TITLE
show splash screen only when `show_logo` is true

### DIFF
--- a/metadrive/engine/core/engine_core.py
+++ b/metadrive/engine/core/engine_core.py
@@ -252,12 +252,12 @@ class EngineCore(ShowBase.ShowBase):
                 if self.mode == RENDER_MODE_ONSCREEN and (not self.global_config["debug"]):
                     if self.global_config["show_logo"]:
                         self._window_logo = attach_logo(self)
-                    self._loading_logo = attach_cover_image(
-                        window_width=self.get_size()[0], window_height=self.get_size()[1]
-                    )
-                    for i in range(5):
-                        self.graphicsEngine.renderFrame()
-                    self.taskMgr.add(self.remove_logo, "remove _loading_logo in first frame")
+                        self._loading_logo = attach_cover_image(
+                            window_width=self.get_size()[0], window_height=self.get_size()[1]
+                        )
+                        for i in range(5):
+                            self.graphicsEngine.renderFrame()
+                        self.taskMgr.add(self.remove_logo, "remove _loading_logo in first frame")
 
         self.closed = False
 


### PR DESCRIPTION
We are currently making a smaller asset folder, and we want to be able to remove all the logos