### PR TITLE
Hotfix the bugs introduced by bounding box env

### DIFF
--- a/metadrive/component/vehicle/base_vehicle.py
+++ b/metadrive/component/vehicle/base_vehicle.py
@@ -145,15 +145,6 @@ class BaseVehicle(BaseObject, BaseVehicleState):
         self.add_body(vehicle_chassis.getChassis())
         self.system = vehicle_chassis
         self.chassis = self.origin
-
-        if self.config["scale"] is not None:
-            w, l, h = self.config["scale"]
-            self.FRONT_WHEELBASE *= l
-            self.REAR_WHEELBASE *= l
-            self.LATERAL_TIRE_TO_CENTER *= w
-            self.TIRE_RADIUS *= h
-            self.CHASSIS_TO_WHEEL_AXIS *= h
-
         self.wheels = self._create_wheel()
 
         # light experimental!
@@ -635,7 +626,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
 
     def _add_visualization(self):
         if self.render:
-            path, scale, offset, HPR = self.path
+            [path, scale, offset, HPR] = self.path
             should_update = (path not in BaseVehicle.model_collection) or (self.config["scale"] is not None)
 
             if should_update:
@@ -659,10 +650,8 @@ class BaseVehicle(BaseObject, BaseVehicleState):
                 car_model.setHpr(*HPR)
                 car_model.setPos(offset[0], offset[1], offset[2] + extra_offset_z)
                 BaseVehicle.model_collection[path] = car_model
-
             else:
                 car_model = BaseVehicle.model_collection[path]
-
             car_model.instanceTo(self.origin)
             if self.config["random_color"]:
                 material = Material()
@@ -704,23 +693,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
             wheel_model = self.loader.loadModel(model_path)
             wheel_model.setTwoSided(self.TIRE_TWO_SIDED)
             wheel_model.reparentTo(wheel_np)
-            tire_scale = 1 * self.TIRE_MODEL_CORRECT if left else -1 * self.TIRE_MODEL_CORRECT
-
-            if self.config['scale'] is not None:
-                tire_scale = (
-                    self.config['scale'][0] * tire_scale, self.config['scale'][1] * tire_scale,
-                    self.config['scale'][2] * tire_scale
-                )
-
-                # A quick workaround here.
-                # The model position is set to height/2 in ScenarioMapManager.
-                # Now we set this offset to -height/2, so that the model will be placed on the ground.
-                # For the wheel, the bottom of it is not z=0, so we add two more terms to correct it.
-                extra_offset = -self.config["height"] / 2 + self.TIRE_RADIUS / self.config['scale'][
-                    2] + self.CHASSIS_TO_WHEEL_AXIS / self.config['scale'][2]
-                wheel_model.setPos(0, 0, extra_offset)
-
-            wheel_model.set_scale(tire_scale)
+            wheel_model.set_scale(1 * self.TIRE_MODEL_CORRECT if left else -1 * self.TIRE_MODEL_CORRECT)
         wheel = self.system.createWheel()
         wheel.setNode(wheel_np.node())
         wheel.setChassisConnectionPointCs(pos)

--- a/metadrive/envs/scenario_env.py
+++ b/metadrive/envs/scenario_env.py
@@ -59,6 +59,12 @@ SCENARIO_ENV_CONFIG = dict(
         lane_line_detector=dict(num_lasers=0, distance=50),
         side_detector=dict(num_lasers=12, distance=50),
     ),
+    # If set_static=True, then the agent will not "fall from the sky". This will be helpful if you want to
+    # capture per-frame data for the agent (for example for collecting static sensor data).
+    # However, the physics engine will not update the position of the agent. So in the visualization, the image will be
+    # very chunky as the agent will not suddenly move to the next position for each step.
+    # Set to False for better visualization.
+    set_static=False,
 
     # ===== Reward Scheme =====
     # See: https://github.com/metadriverse/metadrive/issues/283
@@ -410,7 +416,8 @@ if __name__ == "__main__":
             # "no_traffic":True,
             # "start_scenario_index": 192,
             # "start_scenario_index": 1000,
-            "num_scenarios": 30,
+            "num_scenarios": 3,
+            "set_static": True,
             # "force_reuse_object_name": True,
             # "data_directory": "/home/shady/Downloads/test_processed",
             "horizon": 1000,
@@ -424,7 +431,7 @@ if __name__ == "__main__":
                 lane_line_detector=dict(num_lasers=12, distance=50),
                 side_detector=dict(num_lasers=160, distance=50)
             ),
-            "data_directory": AssetLoader.file_path("nuplan", unix_style=False),
+            "data_directory": AssetLoader.file_path("nuscenes", unix_style=False),
         }
     )
     success = []

--- a/metadrive/manager/scenario_traffic_manager.py
+++ b/metadrive/manager/scenario_traffic_manager.py
@@ -211,10 +211,11 @@ class ScenarioTrafficManager(BaseManager):
         v_cfg["width"] = state["width"]
         v_cfg["length"] = state["length"]
         v_cfg["height"] = state["height"]
-        v_cfg["scale"] = (
-            v_cfg["width"] / vehicle_class.DEFAULT_WIDTH, v_cfg["length"] / vehicle_class.DEFAULT_LENGTH,
-            v_cfg["height"] / vehicle_class.DEFAULT_HEIGHT
-        )
+        if use_bounding_box:
+            v_cfg["scale"] = (
+                v_cfg["width"] / vehicle_class.DEFAULT_WIDTH, v_cfg["length"] / vehicle_class.DEFAULT_LENGTH,
+                v_cfg["height"] / vehicle_class.DEFAULT_HEIGHT
+            )
 
         if self.engine.global_config["top_down_show_real_size"]:
             v_cfg["top_down_length"] = track["state"]["length"][self.episode_step]

--- a/metadrive/policy/replay_policy.py
+++ b/metadrive/policy/replay_policy.py
@@ -63,7 +63,14 @@ class ReplayTrafficParticipantPolicy(BasePolicy):
         self.control_object.set_velocity(info["velocity"], in_local_frame=self._velocity_local_frame)
         self.control_object.set_heading_theta(info["heading"])
         self.control_object.set_angular_velocity(info["angular_velocity"])
-        self.control_object.set_static(True)
+
+        # If set_static, then the agent will not "fall from the sky".
+        # However, the physics engine will not update the position of the agent.
+        # So in the visualization, the image will be very chunky as the agent will not suddenly move to the next
+        # position for each step.
+
+        if self.engine.global_config.get("set_static", False):
+            self.control_object.set_static(True)
 
         return None  # Return None action so the base vehicle will not overwrite the steering & throttle
 


### PR DESCRIPTION
## What changes do you make in this PR?

* Please describe why you create this PR

The bugs are:

1. If use log replay ego policy, the visualization will be flickerring because the agent update position each step. Solution: introduce config `set_static` and default to False. Need to turn it on in SimGen.
2. The tire of the agents are completely wrong in ScenarioEnv. Some agents might miss their tires. This is fixed by only passing in `vehicle_config['scale']` when using bounding box.




## Checklist

* [x] I have merged the latest main branch into current branch.
* [x] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
