### PR TITLE
A basic traffic mode for PGTrafficManager

### DIFF
--- a/metadrive/manager/traffic_manager.py
+++ b/metadrive/manager/traffic_manager.py
@@ -20,7 +20,7 @@ BlockVehicles = namedtuple("block_vehicles", "trigger_road vehicles")
 class TrafficMode:
     # Traffic vehicles will be spawned once
     Basic = "basic"
-    
+
     # Traffic vehicles will be respawned, once they arrive at the destinations
     Respawn = "respawn"
 
@@ -29,6 +29,7 @@ class TrafficMode:
 
     # Hybrid, some vehicles are triggered once on map and disappear when arriving at destination, others exist all time
     Hybrid = "hybrid"
+
 
 class PGTrafficManager(BaseManager):
     VEHICLE_GAP = 10  # m
@@ -105,7 +106,7 @@ class PGTrafficManager(BaseManager):
             v.after_step()
             if not v.on_lane:
                 v_to_remove.append(v)
-                
+
         for v in v_to_remove:
             vehicle_type = type(v)
             self.clear_objects([v.id])


### PR DESCRIPTION
## Rationale

I realised that PGTrafficManager is missing a basic mode that would disable both Triggering and Respawning background vehicles.

The modes of traffic in PGTraffic manager can be put in the table:

|                        | Triggering | Respawning |
| ---------------------- | ---------- | ---------- |
| `Trigger Mode`         | ✅          | :no_entry_sign:          |
| `Respawn Mode`         | :no_entry_sign:          | ✅          |
| `Hybrid Mode`          | ✅          | ✅          |
| **(new)** `Basic Mode` | :no_entry_sign:          | :no_entry_sign:          |

The basic mode can be usefull for evaluating agents in simple scenarios where scenario execution is determined by the initial state:

![output](https://github.com/user-attachments/assets/c5ec64a9-08fd-4c64-a7df-61c2219801b4)



## What changes do you make in this PR?

- Added a TrafficMode.Basic
- Addapted `PGTrafficManager` to accept "basic" traffic mode
- Added example to documentation in `rl_enviroments.ipynb`

## Checklist

* [X] I have merged the latest main branch into current branch.
* [X] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
