### PR TITLE
Fix minor bug in `get_number_summary` - Use class instead of instance for static fields

### DIFF
--- a/metadrive/scenario/scenario_description.py
+++ b/metadrive/scenario/scenario_description.py
@@ -479,9 +479,9 @@ class ScenarioDescription(dict):
 
         # If object summary does not exist, fill them here
         object_summaries = {}
-        for track_id, track in scenario[scenario.TRACKS].items():
-            object_summaries[track_id] = scenario.get_object_summary(object_dict=track, object_id=track_id)
-        scenario[scenario.METADATA][scenario.SUMMARY.OBJECT_SUMMARY] = object_summaries
+        for track_id, track in scenario[ScenarioDescription.TRACKS].items():
+            object_summaries[track_id] = ScenarioDescription.get_object_summary(object_dict=track, object_id=track_id)
+        scenario[ScenarioDescription.METADATA][ScenarioDescription.SUMMARY.OBJECT_SUMMARY] = object_summaries
 
         # moving object
         number_summary_dict.update(ScenarioDescription._calculate_num_moving_objects(scenario))


### PR DESCRIPTION
In `get_number_summary`, a few static fields and functions were being accessed from an instance of ScenarioDescription rather than the class.

## What changes do you make in this PR?

In `scenario_description.py` the `get_number_summary` function does not work because it tries to use an instance of ScenarioDescription instead of the class itself to try to call static functions and use constants that are defined in the class. I replaced these instances with the class.

* Please describe why you create this PR

Fix minor bug 

## Checklist

* [ X ] I have merged the latest main branch into current branch.
* [ X ] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
